### PR TITLE
mask nicknames in IRC with unicode word joiners

### DIFF
--- a/ircbot/ircbot.go
+++ b/ircbot/ircbot.go
@@ -43,11 +43,20 @@ func (i *Bot) Start() (chan *MessageEvent, error) {
 	return i.chEvents, nil
 }
 
+func insertNBS(s string) string {
+    var buffer bytes.Buffer
+    for _,rune := range s {
+       buffer.WriteRune(rune)
+       buffer.WriteRune('\u2060')
+    }
+    return buffer.String()
+}
+
 func (i *Bot) SendMessage(nick, msg, channel string, flag bool) {
 	msgBuf := bytes.NewBufferString("")
 
 	if flag == true {
-		fmt.Fprintf(msgBuf, "%s:%s", nick, msg)
+		fmt.Fprintf(msgBuf, "%s:%s", insertNBS(nick), msg)
 	} else {
 		fmt.Fprintf(msgBuf, "%s", msg)
 	}


### PR DESCRIPTION
Some uesrs who are connected to slack and IRC at the same time compained that the IRC-Part of the bridge mentions them every time they write anything in the slack. That's annoying. The solution is to insert an unicode word joiner after every character of the nickname. That causes the IRC-Client not to notice that their nick was mentioned supressing the annoying notification.

That was my first time to write any go code, therefore I know that this code could be very ugly and I do understand if you do not want to merge it. I just want to share it with you because you might think it's usefull.
